### PR TITLE
Fix/warning trianvol no rval

### DIFF
--- a/R/trivolume.r
+++ b/R/trivolume.r
@@ -14,7 +14,6 @@ trivolume <- function(mesh1,mesh2)
     #mesh2 <- invertFaces(mesh2)
     vb1 <- mesh1$vb
     vb2 <- mesh2$vb
-    V <- 0; storage.mode(V) <- "double"
     it <- mesh1$it-1L; storage.mode(it) <- "integer"
     out <- .Call("trianvol",vb1,vb2,it)
     return(out)

--- a/R/trivolume.r
+++ b/R/trivolume.r
@@ -4,7 +4,7 @@
 #'
 #' @param mesh1 triangular mesh in first state
 #' @param mesh2 triangular mesh in second state
-#' @return Volume
+#' @return Volume (\code{NA_real_} on failure)
 #' @export trivolume
 trivolume <- function(mesh1,mesh2)
   {

--- a/R/trivolume.r
+++ b/R/trivolume.r
@@ -14,8 +14,8 @@ trivolume <- function(mesh1,mesh2)
     #mesh2 <- invertFaces(mesh2)
     vb1 <- mesh1$vb
     vb2 <- mesh2$vb
-    it <- mesh1$it-1; storage.mode(it) <- "integer"
     V <- 0; storage.mode(V) <- "double"
+    it <- mesh1$it-1L; storage.mode(it) <- "integer"
     out <- .Call("trianvol",vb1,vb2,it)
     return(out)
   }

--- a/man/trivolume.Rd
+++ b/man/trivolume.Rd
@@ -12,7 +12,7 @@ trivolume(mesh1, mesh2)
 \item{mesh2}{triangular mesh in second state}
 }
 \value{
-Volume
+Volume (\code{NA_real_} on failure)
 }
 \description{
 Calculate volume between two states of a mesh by dividing it into prisms

--- a/src/triangvol.cpp
+++ b/src/triangvol.cpp
@@ -6,6 +6,8 @@ using namespace arma;
 typedef unsigned int uint;
 
 RcppExport SEXP trianvol(SEXP vb1_, SEXP vb2_, SEXP it_) {
+  double V = 0.0;
+  
   try {
   NumericMatrix vb1(vb1_);
   NumericMatrix vb2(vb2_);
@@ -25,7 +27,6 @@ RcppExport SEXP trianvol(SEXP vb1_, SEXP vb2_, SEXP it_) {
   uvec tmp02; tmp02 << 0 << 1 << 2 << endr;
   uvec tmp453; tmp453 << 4 << 5 << 3 << endr;
   int dimit = it.ncol();
-  double V = 0.0;
   for (unsigned int i = 0; i < dimit; i++) {
     double Vtmp = 0.0;
     uvec slice0 = uIT.col(i);
@@ -39,6 +40,10 @@ RcppExport SEXP trianvol(SEXP vb1_, SEXP vb2_, SEXP it_) {
     }
     V += Vtmp/6;
   }
+  } catch (...)
+  {
+  V=NA_REAL;
+  }
+  
   return wrap(V);
-  } catch (...) {}
 }


### PR DESCRIPTION
clang gave me this warning:

triangvol.cpp:44:1: warning: control may reach end of non-void function [-Wreturn-type]

this PR is layered on top of the first PR, so taking that one first will simplify this.
