### PR TITLE
only include omp.h if open mp is available

### DIFF
--- a/src/gaussDisplace.cpp
+++ b/src/gaussDisplace.cpp
@@ -1,5 +1,10 @@
 #include "RcppArmadillo.h"
+
+#include <Rconfig.h>
+#ifdef SUPPORT_OPENMP
 #include <omp.h>
+#endif
+
 using namespace Rcpp;
 using namespace arma;
 


### PR DESCRIPTION
- see http://cran.r-project.org/doc/manuals/r-release/R-exts.html#OpenMP-support
  for details
- closes https://github.com/zarquon42b/mesheR/issues/1
