### PR TITLE
fix for multiple offset values

### DIFF
--- a/R/meshOffset.r
+++ b/R/meshOffset.r
@@ -24,6 +24,6 @@ meshOffset <- function(mesh,offset)
   if (is.null(mesh$normals))
     mesh <- vcgUpdateNormals(mesh)
 
-  mesh$vb[1:3,] <- mesh$vb[1:3,]+offset*mesh$normals[1:3,]
+  mesh$vb[1:3,] <- mesh$vb[1:3,]+t(offset*t(mesh$normals[1:3,]))
   invisible(mesh)
 }


### PR DESCRIPTION
The operation `offset*mesh$normals[1:3,]` produces a by column multiplication instead of a by row multiplication.
